### PR TITLE
Add router and home screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "vue": "^3.5.13"
+    "vue": "^3.5.13",
+    "vue-router": "^4.2.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^5.2.3",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,19 +1,9 @@
 <script setup>
-import AttendanceRegister from './components/AttendanceRegister.vue'
 </script>
 
 <template>
-  <div class="container">
-    <h1>出勤管理システム</h1>
-    <AttendanceRegister />
-  </div>
+  <router-view />
 </template>
 
 <style scoped>
-.container {
-  max-width: 600px;
-  margin: 2rem auto;
-  padding: 1rem;
-  text-align: center;
-}
 </style>

--- a/src/Attendance.vue
+++ b/src/Attendance.vue
@@ -1,0 +1,19 @@
+<script setup>
+import AttendanceRegister from './components/AttendanceRegister.vue'
+</script>
+
+<template>
+  <div class="container">
+    <h1>出勤管理システム</h1>
+    <AttendanceRegister />
+  </div>
+</template>
+
+<style scoped>
+.container {
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 1rem;
+  text-align: center;
+}
+</style>

--- a/src/Home.vue
+++ b/src/Home.vue
@@ -1,0 +1,25 @@
+<script setup>
+import { useRouter } from 'vue-router'
+const router = useRouter()
+const goToApp = () => {
+  router.push('/app')
+}
+</script>
+
+<template>
+  <div class="home">
+    <h1>ホーム</h1>
+    <button @click="goToApp">アプリを開く</button>
+  </div>
+</template>
+
+<style scoped>
+.home {
+  text-align: center;
+  margin-top: 2rem;
+}
+button {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+}
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -2,5 +2,6 @@ import './assets/main.css'
 
 import { createApp } from 'vue'
 import App from './App.vue'
+import router from './router'
 
-createApp(App).mount('#app')
+createApp(App).use(router).mount('#app')

--- a/src/router.js
+++ b/src/router.js
@@ -1,0 +1,13 @@
+import { createRouter, createWebHistory } from 'vue-router'
+import Home from './Home.vue'
+import Attendance from './Attendance.vue'
+
+const routes = [
+  { path: '/', component: Home },
+  { path: '/app', component: Attendance }
+]
+
+export default createRouter({
+  history: createWebHistory(),
+  routes
+})


### PR DESCRIPTION
## Summary
- add `vue-router` dependency
- set up router with `Home.vue` and existing Attendance page
- switch root `App.vue` to a router-view container
- wire router into main entrypoint

## Testing
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68527dac820483268e4e63001f20c539